### PR TITLE
Add ability to switch content type to html

### DIFF
--- a/node.html
+++ b/node.html
@@ -5,7 +5,8 @@
         defaults: {
             from: {value:""},
             to: {value:""},
-            name: {value:""}
+            name: {value:""},
+            content: {value:"text"}
         },
         credentials: {
             key: {type:"password"},

--- a/node.html
+++ b/node.html
@@ -37,6 +37,13 @@
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
+    <div class="form-row">
+        <label for="node-input-content"><i class="fa fa-code"></i> Content Type</label>
+        <select id="node-input-content">
+            <option>text</option>
+            <option>html</option>
+        </select>
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="sendgrid">

--- a/node.js
+++ b/node.js
@@ -12,7 +12,14 @@ module.exports = function(RED) {
                 cc: msg.cc,
                 bcc: msg.bcc,                
                 subject: msg.topic || msg.title || 'Message from Node-RED',
-                text: msg.payload.toString()
+                
+                if (config.content === "html"){
+                    html: msg.payload.toString()
+                }
+                else
+                {
+                    text: msg.payload.toString()
+                }
             };
             sgMail.send(data, function(err) {
                 if (err) {


### PR DESCRIPTION
Looking at the sendgrid docs, it seems that the only thing that needs to be different is setting of html parameter instead of text. So I made a simple switch. I don't currently have a way of testing this, but tried to do my best by eye. Let me know if it fails test.  
